### PR TITLE
recovery: Separate blkid.tab for vold in recovery

### DIFF
--- a/etc/init.rc
+++ b/etc/init.rc
@@ -125,6 +125,7 @@ service adbd /sbin/adbd --root_seclabel=u:r:su:s0 --device_banner=recovery
 service vold /sbin/minivold
     socket vold stream 0660 root mount
     ioprio be 2
+    setenv BLKID_FILE /tmp/vold_blkid.tab
     seclabel u:r:vold:s0
 
 # setup_adbd will start adb once it has checked the keys


### PR DESCRIPTION
vold does not have selinux permissions to read/write files in rootfs.
By default, libext2_blkid writes a cache file to /etc/blkid.tab. Set
environment variable BLKID_FILE just for use by the vold service,
changing the cache file location to /tmp/vold_blkid.tab which can then
take advantage of context vold_tmpfs.

Change-Id: I70d233d3d6f4e82bc7d781a04ef7707b733b4a1b
